### PR TITLE
Combined Source Term lookups

### DIFF
--- a/Eos/EosParams.H
+++ b/Eos/EosParams.H
@@ -11,7 +11,7 @@
 namespace pele {
 namespace physics {
 namespace eos {
-  
+
 struct GammaLaw;
 struct Fuego;
 struct SRK;
@@ -54,6 +54,7 @@ struct EosParm<Manifold>
   int idx_density{0};
   int idx_T{0};
   int idx_Wdot[NUM_SPECIES - 1] = {0};
+  bool has_mani_src = false;
 };
 
 template <>
@@ -72,6 +73,7 @@ struct InitEosParm<Manifold>
 
     amrex::ParmParse pp("eos");
     pp.get("nominal_pressure_cgs", eosparm->Pnom_cgs);
+    pp.query("has_mani_src", eosparm->has_mani_src);
 
     // Get important indices
     eosparm->idx_density = get_var_index("RHO", manf_data_in);
@@ -79,7 +81,7 @@ struct InitEosParm<Manifold>
 
     // For manifold table parameter source terms, assume if index not found, source term is 0
     // For neural net, require a definition to be supplied for each manifold parameter
-    if(manf_data_in->manmodel == ManifoldModel::TABLE)
+    if(eosparm->has_mani_src)
     {
       for (int idim = 0; idim < manf_data_in->Ndim; idim++)
       {
@@ -107,7 +109,7 @@ struct InitEosParm<Manifold>
       {
         // The info file / metadata loader will ensure we have a definition for each
         eosparm->idx_Wdot[idim] = -1;
-      }  
+      }
     }
   }
 };

--- a/Eos/Manifold.H
+++ b/Eos/Manifold.H
@@ -167,15 +167,10 @@ struct Manifold
   AMREX_FORCE_INLINE
   void RTY2WDOT(const amrex::Real /*R*/, const amrex::Real /*T*/, const amrex::Real Y[], amrex::Real WDOT[])
   {
-    // Look up species sources in table if they exist, otherwise they are 0
-    for(int is = 0; is < NUM_SPECIES-1; is++)
-    {
-      if(eosparm->idx_Wdot[is] >= 0) 
-      {
-	      manfunc->get_value(eosparm->idx_Wdot[is], Y, WDOT[is]);
-      }
-      else
-      {
+    if (eosparm->has_mani_src) {
+      manfunc->get_values(NUM_SPECIES-1, eosparm->idx_Wdot, Y, WDOT);
+    } else {
+      for(int is = 0; is < NUM_SPECIES-1; is++) {
         manfunc->calculate_Wdot(is, Y, WDOT[is]);
       }
     }
@@ -231,7 +226,7 @@ struct Manifold
   Manifold(const EosParm<Manifold>* eparm)
   {
     eosparm = eparm;
-    
+
     if(eosparm->manf_data->manmodel == ManifoldModel::TABLE)
     {
       TabFuncParams::TabFuncData* tf_data =

--- a/Eos/ManifoldFunc.H
+++ b/Eos/ManifoldFunc.H
@@ -3,7 +3,7 @@
 
 namespace pele {
 namespace physics {
-  
+
 enum class ManifoldModel
 {
   TABLE = 0,
@@ -18,7 +18,7 @@ public:
   virtual void allocate() = 0;
   virtual void deallocate() = 0;
   virtual void sync_to_device() = 0;
-  
+
   struct ManFuncData
   {
     ManifoldModel manmodel;
@@ -30,10 +30,10 @@ public:
     char* dimnames; // Names of the manifold parameters (including the passed variables)
     char* varnames; // Names of the output variables
   };
-  
+
   virtual ManFuncData& host_manfunc_data() = 0;
   virtual ManFuncData* device_manfunc_data() = 0;
-  
+
   virtual ~ManFuncParams() {}
 
 }; // class ManFuncParams
@@ -41,7 +41,7 @@ public:
 AMREX_FORCE_INLINE
 int get_var_index(const char* varname, const ManFuncParams::ManFuncData* manf_data,
     const bool require = true)
-{      
+{
   std::string var(varname);
   int ii;
   for (ii = 0; ii < manf_data->Nvar; ii++) {
@@ -65,16 +65,19 @@ public:
   virtual void get_value(const int ivar, const amrex::Real indata[], amrex::Real& out) = 0;
 
   AMREX_GPU_HOST_DEVICE
+  virtual void get_values(const int nvar, const int ivar[], const amrex::Real indata[], amrex::Real out[]) = 0;
+
+  AMREX_GPU_HOST_DEVICE
   virtual void get_derivs(const int ivar, const amrex::Real indata[], amrex::Real derivs[]) = 0;
-  
+
   AMREX_GPU_HOST_DEVICE
   virtual void calculate_Wdot(const int paramidx, const amrex::Real indata[], amrex::Real& out) = 0;
-  
+
   AMREX_GPU_HOST_DEVICE
   virtual ManifoldModel model() = 0;
-  
+
   virtual ~ManifoldFunc() {}
-  
+
 }; // class ManifoldFunc
 }  // namespace physics
 }  // namespace pele

--- a/Eos/NeuralNet.H
+++ b/Eos/NeuralNet.H
@@ -11,7 +11,7 @@
 
 namespace pele {
 namespace physics {
-  
+
 namespace TensorParams
 {
   // Whether we are on a GPU or not
@@ -35,25 +35,25 @@ namespace TensorParams
 class NNFuncParams: public ManFuncParams
 {
 public:
-  
+
   NNFuncParams()
   {
 #ifdef AMREX_USE_GPU
     amrex::Abort("Neural network derived manifolds do not support GPUs at this time.");
 #endif
   }
-  
+
   ~NNFuncParams() {}
 
   virtual void initialize()
   {
     m_h_nnf_data.manmodel = ManifoldModel::NEURAL_NET;
-    
+
     amrex::ParmParse pp("manifold");
-    
+
     std::string nn_filename;
     pp.get("filename", nn_filename);
-    
+
     torch::jit::script::Module nnmodel;
     try
     {
@@ -70,60 +70,60 @@ public:
     {
       amrex::Error("Unable to load neural network model for manifold EOS.");
     }
-    
+
     // The nnmodel should be freed up automatically once it goes out of scope
     // The code below clears the Torch GPU cache
     // c10::cuda::CUDACachingAllocator::empty_cache();
-    
+
     std::string info_filename;
     pp.get("info_filename", info_filename);
-    
+
     strncpy(m_h_nnf_data.nn_filename, nn_filename.c_str(), m_h_nnf_data.len_str*sizeof(char));
     m_h_nnf_data.nn_filename[m_h_nnf_data.len_str] = '\0';
-    
+
     m_h_nnf_data.nnmodel = nnmodel;
-    
+
     read_metadata(info_filename);
-    
+
     pp.query("v", m_verbose);
     if(m_verbose >= 1) print();
-    
+
     allocate();
   }
-  
+
   void read_metadata(std::string& info_filename)
   {
     std::ifstream fi(info_filename, std::ios::in);
-    
+
     constexpr int READING_VAR = 0;
     constexpr int READING_VAL = 1;
     constexpr int READING_COMMENT = 2;
     constexpr int LINE_BREAK = 3;
-    
+
     int state = READING_VAR;
-    
+
     std::unordered_map<std::string, std::vector<std::string> > umap;
     std::string cur_var;
     std::string str;
-    
+
     int str_size = m_h_nnf_data.len_str*sizeof(char);
     int str_len = m_h_nnf_data.len_str;
-    
+
     if(!fi.is_open())
     {
       amrex::Abort("Unable to open supplementary info file for neural net manifold EOS.");
     }
-    
+
     fi.seekg(0, std::ios::end);
     std::streampos length = fi.tellg();
     fi.seekg(0, std::ios::beg);
 
     std::vector<char> buffer(length);
-    fi.read(buffer.data(), length); 
+    fi.read(buffer.data(), length);
     std::istringstream is(std::string(buffer.data(), length));
-    
+
     while(!is.eof())
-    {        
+    {
       if(is.peek() == '\n')
       {
         if(state == LINE_BREAK)
@@ -135,32 +135,32 @@ public:
             state = READING_VAR;
         }
       }
-      
+
       is >> str;
-      
+
       if(str == "#")
       {
         state = READING_COMMENT;
         continue;
       }
-      
+
       if(state == READING_COMMENT)
       {
         continue;
       }
-      
+
       if(str == "=")
       {
         state = READING_VAL;
         continue;
       }
-      
+
       if(str == "\\")
       {
         state = LINE_BREAK;
         continue;
       }
-      
+
       if(state == READING_VAR)
       {
         for(int i = 0; i < str.length(); i++)
@@ -170,28 +170,28 @@ public:
         cur_var = str;
         umap[cur_var] = std::vector<std::string>();
       }
-      
+
       if(state == READING_VAL)
       {
         umap[cur_var].push_back(str);
       }
     }
-    
+
     AMREX_ALWAYS_ASSERT(umap["model_name"].size() == 1);
     AMREX_ALWAYS_ASSERT(umap["ndim"].size() == 1);
     AMREX_ALWAYS_ASSERT(umap["nvar"].size() == 1);
     AMREX_ALWAYS_ASSERT(umap["nmanpar"].size() == 1);
-    
+
     strncpy(m_h_nnf_data.model_name, umap["model_name"][0].c_str(), str_size);
     m_h_nnf_data.model_name[str_len] = '\0';
-    
+
     m_h_nnf_data.Ndim = stoi(umap["ndim"][0]);
     m_h_nnf_data.Nvar = stoi(umap["nvar"][0]);
     m_h_nnf_data.Nmanpar = stoi(umap["nmanpar"][0]);
-    
+
     AMREX_ALWAYS_ASSERT(umap["dimnames"].size() == m_h_nnf_data.Ndim);
     AMREX_ALWAYS_ASSERT(umap["varnames"].size() == m_h_nnf_data.Nvar);
-    
+
     m_h_nnf_data.dimnames = static_cast<char*>(amrex::The_Pinned_Arena()->alloc(m_h_nnf_data.Ndim*str_size));
     std::vector<std::string>& dimnames = umap["dimnames"];
     for(int i = 0; i < m_h_nnf_data.Ndim; i++)
@@ -200,7 +200,7 @@ public:
       std::string sd = dimnames[i] + std::string(str_len - dimnames[i].length(), ' ');
       strncpy(&m_h_nnf_data.dimnames[i*str_len], sd.c_str(), str_size);
     }
-    
+
     m_h_nnf_data.varnames = static_cast<char*>(amrex::The_Pinned_Arena()->alloc(m_h_nnf_data.Nvar*str_size));
     std::vector<std::string>& varnames = umap["varnames"];
     for(int i = 0; i < m_h_nnf_data.Nvar; i++)
@@ -209,7 +209,7 @@ public:
       std::string sv = varnames[i] + std::string(str_len - varnames[i].length(), ' ');
       strncpy(&m_h_nnf_data.varnames[i*str_len], sv.c_str(), str_size);
     }
-    
+
     m_h_nnf_data.Ncomb = umap["def_" + amrex::trim(dimnames[0])].size();
     m_h_nnf_data.comb_coeff = static_cast<amrex::Real*>(
         amrex::The_Pinned_Arena()->alloc(m_h_nnf_data.Ndim*m_h_nnf_data.Ncomb*sizeof(amrex::Real)));
@@ -244,7 +244,7 @@ public:
         m_h_nnf_data.comb_src_idx[i*m_h_nnf_data.Ncomb + j] = src_idx;
       }
     }
-    
+
     m_h_nnf_data.man_bias = static_cast<amrex::Real*>(
         amrex::The_Pinned_Arena()->alloc(m_h_nnf_data.Ndim*sizeof(amrex::Real)));
     std::vector<std::string>& man_bias = umap["manibiases"];
@@ -254,7 +254,7 @@ public:
       m_h_nnf_data.man_bias[i] = (amrex::Real)std::stod(man_bias[i]);
     }
   }
-  
+
   void print()
   {
     amrex::Print() << std::endl;
@@ -265,7 +265,7 @@ public:
     amrex::Print() << "Nvar: " << m_h_nnf_data.Nvar << std::endl;
     amrex::Print() << "Nmanpar: " << m_h_nnf_data.Nmanpar << std::endl;
     amrex::Print() << std::endl;
-    
+
     amrex::Print() << "Dimnames: Index | Variable Name" << std::endl;
     for(int i = 0; i < m_h_nnf_data.Ndim; i++)
     {
@@ -273,7 +273,7 @@ public:
       amrex::Print() << i << " | " << amrex::trim(dimname) << std::endl;
     }
     amrex::Print() << std::endl;
-    
+
     amrex::Print() << "Varnames: Index | Variable Name" << std::endl;
     for(int i = 0; i < m_h_nnf_data.Nvar; i++)
     {
@@ -281,9 +281,9 @@ public:
       amrex::Print() << i << " | " << amrex::trim(varname) << std::endl;
     }
     amrex::Print() << std::endl;
-    
+
     amrex::Print() << "Ncomb: " << m_h_nnf_data.Ncomb << std::endl;
-    
+
     for(int i = 0; i < m_h_nnf_data.Ndim; i++)
     {
       std::string dimname(&m_h_nnf_data.dimnames[i*m_h_nnf_data.len_str], m_h_nnf_data.len_str);
@@ -298,7 +298,7 @@ public:
         if(src_idx >= 0)
         {
           src_varname = std::string(&m_h_nnf_data.varnames[src_idx*m_h_nnf_data.len_str],
-              m_h_nnf_data.len_str);  
+              m_h_nnf_data.len_str);
         }
         else
         {
@@ -306,9 +306,9 @@ public:
         }
         amrex::Print() << amrex::trim(varname) << " | " << amrex::trim(src_varname) << " | " << coeff << std::endl;
       }
-      
+
       amrex::Print();
-      
+
       amrex::Print() << std::endl;
     }
   }
@@ -331,7 +331,7 @@ public:
     amrex::The_Pinned_Arena()->free(m_h_nnf_data.comb_idx);
     amrex::The_Pinned_Arena()->free(m_h_nnf_data.comb_coeff);
     amrex::The_Pinned_Arena()->free(m_h_nnf_data.man_bias);
-    
+
     // if(m_device_allocated)
     // {
     //   amrex::The_Device_Arena()->free(m_d_nnf_data);
@@ -350,7 +350,7 @@ public:
     //                    m_d_nnf_data);
     // }
   }
-  
+
   struct NNFuncData: ManFuncParams::ManFuncData
   {
     char nn_filename[len_str+1]; // Path to neural network file
@@ -361,12 +361,12 @@ public:
     int* comb_src_idx; // Index of source term for variable corresponding to each comb_coeff
     amrex::Real* man_bias; // Offsets to add when calculating manifold parameters
   };
-  
+
   virtual ManFuncData& host_manfunc_data()
   {
     return m_h_nnf_data;
   }
-  
+
   virtual ManFuncData* device_manfunc_data()
   {
     return &m_h_nnf_data;
@@ -385,12 +385,12 @@ public:
   }
 
 private:
-  
+
   int m_verbose = 0;
   NNFuncData m_h_nnf_data;
   NNFuncData* m_d_nnf_data;
   bool m_device_allocated{false};
-  
+
 };
 
 class NNFunc: public ManifoldFunc
@@ -420,6 +420,16 @@ public:
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
+  virtual void get_values(const int nvar, const int ivar[], const amrex::Real indata[], amrex::Real out[])
+  {
+    // Ostensibly cannot use from_blob because the indata array is const
+    torch::Tensor intensor = torch::empty({1, nnf_data->Ndim}, TensorParams::tensoropt);
+    std::memcpy(intensor.data_ptr(), indata, sizeof(amrex::Real) * intensor.numel());
+    get_values(nvar, ivar, intensor, out);
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
   virtual void get_derivs(const int ivar, const amrex::Real indata[], amrex::Real derivs[])
   {
     // Ostensibly cannot use from_blob because the indata array is const
@@ -427,7 +437,7 @@ public:
     std::memcpy(intensor.data_ptr(), indata, sizeof(amrex::Real) * intensor.numel());
     get_derivs(ivar, intensor, derivs);
   }
-  
+
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   virtual void calculate_Wdot(const int paramidx, const amrex::Real indata[], amrex::Real& out)
@@ -437,7 +447,7 @@ public:
     std::memcpy(intensor.data_ptr(), indata, sizeof(amrex::Real) * intensor.numel());
     calculate_Wdot(paramidx, intensor, out);
   }
-  
+
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   virtual ManifoldModel model()
@@ -446,7 +456,7 @@ public:
   }
 
 private:
-  
+
   // Variables
   NNFuncParams::NNFuncData* nnf_data;
 
@@ -474,6 +484,18 @@ private:
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
+  void get_values(const int nvar, const int ivar[], const torch::Tensor& indata, amrex::Real out[])
+  {
+    torch::Tensor predvars = eval_model(indata);
+    auto acc = predvars.accessor<amrex::Real,1>();
+
+    for (int i = 0; i < nvar; i++) {
+      out[i] = (ivar[i] > 0) ? acc[ivar[i]] : 0.0;
+    }
+  }
+
+  AMREX_GPU_HOST_DEVICE
+  AMREX_FORCE_INLINE
   void get_derivs(const int ivar, torch::Tensor& indata, amrex::Real derivs[])
   {
     torch::Tensor out_tensor = eval_model(ivar, indata);
@@ -487,16 +509,16 @@ private:
       derivs[i] = acc[0][i];
     }
   }
-  
+
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void calculate_Wdot(const int paramidx, const torch::Tensor& indata, amrex::Real& out)
   {
     torch::Tensor predvars = eval_model(indata);
     auto acc = predvars.accessor<amrex::Real,1>();
-    
+
     amrex::Real rr = 0.0;
-    
+
     for(int j = 0; j < nnf_data->Ncomb; j++)
     {
       const int& idx = nnf_data->comb_src_idx[paramidx*nnf_data->Ncomb + j];
@@ -504,7 +526,7 @@ private:
       const amrex::Real src_term = (idx < 0) ? 0.0 : acc[idx];
       rr += coeff*src_term;
     }
-    
+
     out = rr;
   }
 

--- a/Eos/Table.H
+++ b/Eos/Table.H
@@ -212,6 +212,24 @@ namespace pele{
         out = interpolate(indices, alphas, &tf_data->values[ivar * tf_data->varSpacing]);
       }
 
+      // Lookup a few variables directly if you already know indices
+      AMREX_GPU_HOST_DEVICE
+      AMREX_FORCE_INLINE
+      virtual void
+      get_values(const int nvar, const int ivar[], const amrex::Real interpdata[], amrex::Real out[])
+      {
+        // Get alphas and indices
+        int indices[MAXD_TABLE];
+        amrex::Real alphas[MAXD_TABLE];
+        amrex::Real dxinv[MAXD_TABLE];
+        get_indices_alphas_dxinv(interpdata, indices, alphas, dxinv);
+
+        // interpolate down
+        for (int i = 0; i < nvar; ++i) {
+          out[i] = (ivar[i] > 0) ? interpolate(indices, alphas, &tf_data->values[ivar[i] * tf_data->varSpacing]) : 0.0;
+        }
+      }
+
       // Get derivatives of indexed variable with respect to table dimensions using finite difference
       AMREX_GPU_HOST_DEVICE
       AMREX_FORCE_INLINE

--- a/Eos/Table.H
+++ b/Eos/Table.H
@@ -15,11 +15,11 @@ namespace pele{
 
       TabFuncParams() {}
       virtual ~TabFuncParams() {}
-      
+
       virtual void initialize()
       {
         m_h_tf_data.manmodel = ManifoldModel::TABLE;
-        
+
         amrex::ParmParse pp("manifold");
         std::string tablefile;
         pp.get("filename", tablefile);
@@ -145,7 +145,7 @@ namespace pele{
         if (m_device_allocated)
           amrex::The_Device_Arena()->free(m_d_tf_data);
       }
-      
+
       virtual void sync_to_device()
       {
         if (!m_device_allocated) {
@@ -155,12 +155,12 @@ namespace pele{
                            m_d_tf_data);
         }
       }
-      
+
       virtual ManFuncData& host_manfunc_data()
       {
         return m_h_tf_data;
       }
-      
+
       virtual ManFuncData* device_manfunc_data()
       {
         return m_d_tf_data;
@@ -227,7 +227,7 @@ namespace pele{
         // finite differences from table
         amrex::Real out = differentiate(indices, alphas, dxinv, &tf_data->values[ivar * tf_data->varSpacing], derivs);
       }
-      
+
       AMREX_GPU_HOST_DEVICE
       AMREX_FORCE_INLINE
       virtual void calculate_Wdot(const int paramidx, const amrex::Real indata[],
@@ -235,12 +235,12 @@ namespace pele{
       {
         out = 0.0;
       }
-      
+
       virtual ManifoldModel model()
       {
         return tf_data->manmodel;
       }
-      
+
       /*
       int idx_density;
       int idx_T;

--- a/Reactions/ReactorRK64.cpp
+++ b/Reactions/ReactorRK64.cpp
@@ -134,6 +134,8 @@ ReactorRK64::react(
           rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp2_rk64);
         dt_rk = amrex::max<amrex::Real>(dt_rk_min, dt_rk * change_factor);
       }
+      // Don't overstep the integration time
+      dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
     }
     d_nsteps[icell] = nsteps;
     // copy data back
@@ -295,6 +297,8 @@ ReactorRK64::react(
           rkp.betaerr_rk64 * pow((captured_abstol / max_err), rkp.exp2_rk64);
         dt_rk = amrex::max<amrex::Real>(dt_rk_min, dt_rk * change_factor);
       }
+      // Don't overstep the integration time
+      dt_rk = amrex::min<amrex::Real>(dt_rk, time_out - current_time);
     }
 
     // copy data back


### PR DESCRIPTION
This does a couple things:

- For both tables and nets, adds an additional function to look up multiple variables at once

- Uses that function in RTY2WDOT to improve efficiency

- Adds capability to compute manifold parameter source terms directly if present in the network (I updated the training script to add this in at the end), if `eos.has_mani_src = true` in the inputs. Otherwise, the present behavior is preserved.