### PR TITLE
log RHO changes

### DIFF
--- a/Eos/EosParams.H
+++ b/Eos/EosParams.H
@@ -51,6 +51,8 @@ struct EosParm<Manifold>
 {
   ManFuncParams::ManFuncData* manf_data;
   amrex::Real Pnom_cgs;
+  bool use_log_density{true};
+  bool compute_temperature{false};
   int idx_density{0};
   int idx_T{0};
   int idx_Wdot[NUM_SPECIES - 1] = {0};
@@ -74,9 +76,15 @@ struct InitEosParm<Manifold>
     amrex::ParmParse pp("eos");
     pp.get("nominal_pressure_cgs", eosparm->Pnom_cgs);
     pp.query("has_mani_src", eosparm->has_mani_src);
+    pp.get("use_log_density", eosparm->use_log_density);
+    pp.get("compute_temperature", eosparm->compute_temperature);
 
     // Get important indices
-    eosparm->idx_density = get_var_index("RHO", manf_data_in);
+    if (eosparm->use_log_density) {
+      eosparm->idx_density = get_var_index("lnRHO", manf_data_in);
+    } else {
+      eosparm->idx_density = get_var_index("RHO", manf_data_in);
+    }
     eosparm->idx_T = get_var_index("T", manf_data_in);
 
     // For manifold table parameter source terms, assume if index not found, source term is 0

--- a/Eos/Fuego.H
+++ b/Eos/Fuego.H
@@ -27,7 +27,7 @@ struct Fuego
       R += RY[is];
     }
   }
-  
+
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void RY2RRinvY(const amrex::Real RY[], amrex::Real &R, amrex::Real &Rinv, amrex::Real Y[] )
@@ -42,11 +42,11 @@ struct Fuego
   // TODO: Make it so this placeholder isn't needed
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  static void Y2dRdY(const amrex::Real* /*Y[]*/, amrex::Real* /*dRdY[]*/)
+  static void RY2dRdY(const amrex::Real& /*R*/, const amrex::Real* /*Y[]*/, amrex::Real* /*dRdY[]*/)
   {
-    amrex::Error("Y2dRdY is not yet implemented for Manifold EOS");
+    amrex::Error("RY2dRdY not applicable for Fuego EOS");
   }
-  
+
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   static void molecular_weight(amrex::Real mw[]) { get_mw(mw); }

--- a/Eos/Manifold.H
+++ b/Eos/Manifold.H
@@ -125,16 +125,22 @@ struct Manifold
   AMREX_FORCE_INLINE
   void HY2T(const amrex::Real /*H*/, const amrex::Real Y[], amrex::Real& T)
   {
-    manfunc->get_value(eosparm->idx_T, Y, T);
-    // amrex::Error("HY2T is not yet implemented for Manifold EOS");
+    if (eosparm->compute_temperature) {
+      manfunc->get_value(eosparm->idx_T, Y, T);
+    } else {
+      T = 1.0;
+    }
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
   void RHY2T(const amrex::Real /*R*/, const amrex::Real /*H*/, const amrex::Real Y[], amrex::Real& T)
   {
-    manfunc->get_value(eosparm->idx_T, Y, T);
-    // amrex::Error("RHY2T is not yet implemented for Manifold EOS");
+    if (eosparm->compute_temperature) {
+      manfunc->get_value(eosparm->idx_T, Y, T);
+    } else {
+      T = 1.0;
+    }
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -202,11 +208,12 @@ struct Manifold
     // Get value of Rho consistent with other state variables
     amrex::Real rho_from_table;
     manfunc->get_value(eosparm->idx_density, Y, rho_from_table);
+    if (eosparm->use_log_density) {
+      rho_from_table = exp(rho_from_table);
+    }
 
     // Return pressure is nominal pressure scaled due to density mismatch
     P = eosparm->Pnom_cgs * R/rho_from_table;
-
-    // amrex::Error("RTY2P is not yet implemented for Manifold EOS");
   }
 
   AMREX_GPU_HOST_DEVICE
@@ -214,14 +221,21 @@ struct Manifold
   void PYT2R(const amrex::Real /*P*/, const amrex::Real Y[], const amrex::Real /*T*/, amrex::Real& R)
   {
     manfunc->get_value(eosparm->idx_density, Y, R);
+    if (eosparm->use_log_density) {
+      R = exp(R);
+    }
   }
 
   AMREX_GPU_HOST_DEVICE
   AMREX_FORCE_INLINE
-  void Y2dRdY(const amrex::Real Y[], amrex::Real dRdY[])
+  void RY2dRdY(const amrex::Real R, const amrex::Real Y[], amrex::Real dRdY[])
   {
     manfunc->get_derivs(eosparm->idx_density, Y, dRdY);
-    // amrex::Error("Y2dRdY is not yet implemented for Manifold EOS");
+    if (eosparm->use_log_density) {
+      for (int is = 0; is < NUM_SPECIES-1; is++) {
+        dRdY[is] *= R;
+      }
+    }
   }
 
   AMREX_GPU_HOST_DEVICE

--- a/Eos/NeuralNet.H
+++ b/Eos/NeuralNet.H
@@ -490,7 +490,7 @@ private:
     auto acc = predvars.accessor<amrex::Real,1>();
 
     for (int i = 0; i < nvar; i++) {
-      out[i] = (ivar[i] > 0) ? acc[ivar[i]] : 0.0;
+      out[i] = (ivar[i] >= 0) ? acc[ivar[i]] : 0.0;
     }
   }
 

--- a/Eos/NeuralNetHomerolled.H
+++ b/Eos/NeuralNetHomerolled.H
@@ -5,13 +5,13 @@
 
 namespace pele {
 namespace physics {
-  
+
 class NNFuncParams: public ManFuncParams
 {
 public:
 
   NNFuncParams() {}
-  
+
   ~NNFuncParams() {}
 
   virtual void initialize()
@@ -27,7 +27,7 @@ public:
     {
       amrex::Abort("Home-rolled neural net file should have .pnn extension.");
     }
-    
+
     bool cmlm_net = false;
     pp.query("cmlm_net", cmlm_net);
 
@@ -40,7 +40,7 @@ public:
     m_h_nnf_data.nn_filename[m_h_nnf_data.len_str] = '\0';
 
     pack_model(nnmodel);
-    
+
     read_metadata(info_filename);
 
     pp.query("v", m_verbose);
@@ -52,19 +52,19 @@ public:
 
     allocate();
   }
-  
+
   void pack_model(NNModel& nnmodel)
   {
     // Get sizes of buffers
     int nreals, nints;
     nnmodel.buffer_sizes_for_packing(nreals, nints);
-    
+
     // Allocate memory for buffers so that they can be copied efficiently to the GPU
     m_h_nnf_data.nnrdata = static_cast<amrex::Real*>(
         amrex::The_Pinned_Arena()->alloc(nreals*sizeof(amrex::Real)));
     m_h_nnf_data.nnidata = static_cast<int*>(
         amrex::The_Pinned_Arena()->alloc(nints*sizeof(int)));
-        
+
     // Pack model
     nnmodel.pack(m_h_nnf_data.nnrdata, m_h_nnf_data.nnidata);
   }
@@ -406,7 +406,7 @@ public:
     const amrex::Real* outdata = nnmodel(indata);
     for(int i = 0; i < nvar; i++)
     {
-      out[i] = (ivar[i] > 0) ? outdata[ivar[i]] : 0.0;  
+      out[i] = (ivar[i] >= 0) ? outdata[ivar[i]] : 0.0;
     }
   }
 
@@ -418,13 +418,13 @@ public:
     constexpr amrex::Real eps = 1e-5;
     const amrex::Real outval0 = nnmodel(indata)[ivar];
     amrex::Real diff;
-    
+
     amrex::Real indata_copy[nnf_data->Ndim];
     for(int i = 0; i < nnf_data->Ndim; i++)
     {
       indata_copy[i] = indata[i];
     }
-    
+
     for(int i = 0; i < nnf_data->Ndim; i++)
     {
       diff = (indata[i] != 0.0) ? eps*indata[i] : eps;
@@ -439,7 +439,7 @@ public:
   virtual void calculate_Wdot(const int paramidx, const amrex::Real indata[], amrex::Real& out)
   {
     const amrex::Real* outdata = nnmodel(indata);
-    
+
     amrex::Real rr = 0.0;
 
     for(int j = 0; j < nnf_data->Ncomb; j++)
@@ -467,7 +467,7 @@ private:
   NNModel nnmodel;
 
 }; // class NNFunc
-  
+
 } // namespace physics
 } // namespace pele
 

--- a/Eos/Table.H
+++ b/Eos/Table.H
@@ -226,7 +226,7 @@ namespace pele{
 
         // interpolate down
         for (int i = 0; i < nvar; ++i) {
-          out[i] = (ivar[i] > 0) ? interpolate(indices, alphas, &tf_data->values[ivar[i] * tf_data->varSpacing]) : 0.0;
+          out[i] = (ivar[i] >= 0) ? interpolate(indices, alphas, &tf_data->values[ivar[i] * tf_data->varSpacing]) : 0.0;
         }
       }
 


### PR DESCRIPTION
Two new options:

`eos.compute_temperature = false` turns off all temperature computations (not used for dynamics in manifold model) 
`eos.use_log_density = true` look up "lnRHO" instead of "RHO" for manifold models. "lnRHO" must be in the table or network